### PR TITLE
Fix report sort order + couple admin actions to bulletin cards

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -11,7 +11,7 @@ import re
 from typing import Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Header, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Header, Query
 from pydantic import BaseModel
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -162,15 +162,17 @@ async def admin_list_incidents(
 async def admin_update_status(
     incident_id: UUID,
     body: StatusUpdate,
+    background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
 ):
     """
     Validate, discard, or reset an incident report.
 
     status values:
-      - "verified"   → validates the report (makes it public/featured)
-      - "rejected"   → discards it from public view
-      - "unverified" → resets to default pending state
+      - "verified"   → validates the report; creates a bulletin card if one doesn't exist,
+                       or restores a previously archived card
+      - "rejected"   → discards the report; archives its linked bulletin card
+      - "unverified" → resets to default pending state (card untouched)
     """
     allowed = {"verified", "rejected", "unverified", "corroborated"}
     if body.status not in allowed:
@@ -184,6 +186,34 @@ async def admin_update_status(
     incident.status = body.status
     if body.admin_note is not None:
         incident.admin_note = body.admin_note
+
+    # ── Couple bulletin card to incident status ────────────────────────────
+    if body.status == "rejected":
+        # Archive the linked bulletin card so it disappears from the public site
+        if incident.matched_bulletin_item_id:
+            card_result = await db.execute(
+                select(BulletinItem).where(BulletinItem.id == incident.matched_bulletin_item_id)
+            )
+            card = card_result.scalar_one_or_none()
+            if card:
+                card.status = "archived"
+
+    elif body.status == "verified":
+        if incident.matched_bulletin_item_id is None:
+            # No card yet (e.g. shitpost check rejected it) — generate one now,
+            # bypassing the quality gate since an admin explicitly validated this report
+            from app.services.bulletin.individual_report_card import generate_card_for_report
+            background_tasks.add_task(
+                generate_card_for_report, str(incident.id), skip_shitpost_check=True
+            )
+        else:
+            # Card exists but may have been archived — restore it
+            card_result = await db.execute(
+                select(BulletinItem).where(BulletinItem.id == incident.matched_bulletin_item_id)
+            )
+            card = card_result.scalar_one_or_none()
+            if card and card.status == "archived":
+                card.status = "active"
 
     # Optionally block the reporter's IP when discarding
     if body.block_ip and body.status == "rejected" and incident.reporter_ip_hash:

--- a/backend/app/api/bulletin.py
+++ b/backend/app/api/bulletin.py
@@ -13,7 +13,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query, HTTPException
 from pydantic import BaseModel
-from sqlalchemy import select, desc, func, nullslast
+from sqlalchemy import select, desc, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db
@@ -107,8 +107,7 @@ async def list_bulletin_items(
         stmt = stmt.where(func.jsonb_array_length(BulletinItem.user_report_ids) > 0)
 
     stmt = stmt.order_by(
-        nullslast(desc(BulletinItem.occurred_at)),
-        desc(BulletinItem.first_seen_at),
+        desc(func.coalesce(BulletinItem.occurred_at, BulletinItem.first_seen_at)),
     )
 
     # Count total (for pagination UI)

--- a/backend/app/services/bulletin/individual_report_card.py
+++ b/backend/app/services/bulletin/individual_report_card.py
@@ -296,11 +296,14 @@ async def _merge_into_existing_card(
     )
 
 
-async def generate_card_for_report(incident_id: str, max_tokens: int = 1024) -> None:
+async def generate_card_for_report(incident_id: str, max_tokens: int = 1024, skip_shitpost_check: bool = False) -> None:
     """
     Background task: create a single BulletinItem for one user-submitted report.
     Calls Gemini to generate a paraphrased, profanity-filtered narrative.
     Opens its own DB session so it runs safely after the request commits.
+
+    Set skip_shitpost_check=True when called for an already admin-validated report
+    to bypass the automatic quality gate.
     """
     async with async_session_maker() as db:
         try:
@@ -313,14 +316,15 @@ async def generate_card_for_report(incident_id: str, max_tokens: int = 1024) -> 
                 return
 
             # ── Shitpost / quality gate ──────────────────────────────────────
-            is_shitpost, sp_reason = await _check_is_shitpost(incident)
-            if is_shitpost:
-                incident.status = "rejected"
-                await db.commit()
-                logger.info(
-                    f"Report {incident_id} rejected as shitpost: {sp_reason}"
-                )
-                return
+            if not skip_shitpost_check:
+                is_shitpost, sp_reason = await _check_is_shitpost(incident)
+                if is_shitpost:
+                    incident.status = "rejected"
+                    await db.commit()
+                    logger.info(
+                        f"Report {incident_id} rejected as shitpost: {sp_reason}"
+                    )
+                    return
 
             company = incident.av_company or "unknown"
             incident_type = incident.incident_type or "other"

--- a/backend/scripts/backfill_verified_cards.py
+++ b/backend/scripts/backfill_verified_cards.py
@@ -62,7 +62,7 @@ async def main() -> None:
             f"({inc.av_company}, {inc.incident_type}, {inc.address or 'no address'})"
         )
         try:
-            await generate_card_for_report(str(inc.id))
+            await generate_card_for_report(str(inc.id), skip_shitpost_check=True)
             success += 1
             logger.info(f"  ✓ Card created for {inc.id}")
         except Exception as exc:


### PR DESCRIPTION
## Summary
- Bulletin board now sorts by `COALESCE(occurred_at, first_seen_at) DESC` so cards always appear in the same order as the dates shown on them
- Admin **Validate** now automatically creates a bulletin card (skipping the shitpost check since you've manually approved it), or restores one that was previously archived
- Admin **Discard** now automatically archives the linked bulletin card so it disappears from the public site
- `backfill_verified_cards.py` updated to skip the shitpost check (run this once on the server to publish the validated report with hash `944751b2…`)

## Test plan
- [ ] Check bulletin board — cards should appear newest-to-oldest with no out-of-order dates
- [ ] Submit a test report, then Discard it in the admin panel — confirm the bulletin card disappears from the site
- [ ] Submit a test report, let it auto-generate a card, then Discard and re-Validate — confirm the card disappears and reappears
- [ ] Run `python -m scripts.backfill_verified_cards` on the server to publish the specific validated report

🤖 Generated with [Claude Code](https://claude.com/claude-code)