### PR TITLE
Hide archived bulletin cards from admin view

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -431,7 +431,7 @@ async def admin_list_bulletin(
     db: AsyncSession = Depends(get_db),
 ):
     """List all bulletin cards for admin review."""
-    filters = []
+    filters = [BulletinItem.status != "archived"]
     if source_platform:
         filters.append(BulletinItem.source_platform == source_platform.lower())
 


### PR DESCRIPTION
Archived cards (discarded via the Reports Queue) were still showing in the Bulletin Cards admin tab, making it look inconsistent with the public site. Now filters them out so only active cards appear in both places.

🤖 Generated with [Claude Code](https://claude.com/claude-code)