### PR TITLE
Fix: new reports stay Pending instead of immediately becoming Corroborated

### DIFF
--- a/backend/app/services/bulletin/individual_report_card.py
+++ b/backend/app/services/bulletin/individual_report_card.py
@@ -295,7 +295,6 @@ async def _merge_into_existing_card(
             card.summary = refined
 
     incident.matched_bulletin_item_id = card.id
-    incident.status = "corroborated"
     await db.flush()
     logger.info(
         f"Merged report {incident.id} into existing card {card.id} "
@@ -424,7 +423,6 @@ async def generate_card_for_report(
             await db.flush()
 
             incident.matched_bulletin_item_id = bulletin_item.id
-            incident.status = "corroborated"
 
             await db.commit()
             logger.info(


### PR DESCRIPTION
## Summary

- New user reports were immediately showing as "Corroborated" in the admin view instead of "Pending"
- `individual_report_card.py` was setting `incident.status = "corroborated"` whenever it generated a bulletin card — even for a single, unconfirmed report
- Removed both premature status assignments so new reports remain `unverified` (Pending in admin) until the clustering service promotes them

## Why this was wrong

"Corroborated" should only be set by `user_report_clustering.py` once ≥2 distinct-IP reports confirm the same event. Creating a bulletin card for a single report is not corroboration.

## Changes

- `backend/app/services/bulletin/individual_report_card.py` — removed `incident.status = "corroborated"` from both the merge-into-existing-card path and the create-new-card path

🤖 Generated with [Claude Code](https://claude.com/claude-code)