### PR TITLE
Adjust post-submission scroll to account for sticky navbar

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -641,7 +641,10 @@ export default function Home() {
 
       setIsSuccess(true);
       setTimeout(() => {
-        successSectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        if (successSectionRef.current) {
+          const top = successSectionRef.current.getBoundingClientRect().top + window.scrollY - 80;
+          window.scrollTo({ top, behavior: 'smooth' });
+        }
       }, 50);
     } catch (error) {
       setSubmitError(


### PR DESCRIPTION
## Summary

Follow-up to #63. The success card was scrolling into view but the sticky navbar was slightly overlapping the top of it. Switched from `scrollIntoView` to a manual `window.scrollTo` with an 80px offset to clear the navbar height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)